### PR TITLE
refactor: Rename inconsistency concepts - MME→TEAM, UME→MEAT

### DIFF
--- a/architecture_decisions.md
+++ b/architecture_decisions.md
@@ -239,12 +239,12 @@ Sample response for waiting for the result or retrieving the result using getRes
 	],
 	"inconsistencies": [
 	{
-		"type": "MissingModelInstance",
+		"type": "TextEntityAbsentFromModel",
 		"reason": "Text indicates that \"integrations\" should be contained in the model(s) but could not be found. (confidence: 0.65)",
 		"sentenceNumber": 39
 	},
 	{
-		"type": "MissingTextForModelElement",
+		"type": "ModelEntityAbsentFromText",
 		"reason": "Model contains an Instance \"Recording Service\" (type: \"uml:Component\")  that seems to be undocumented.",
 		"modelElementId": "_kvWs4FkHEeyewPSmlgszyA"
 	}

--- a/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/rest/api/converter/InconsistencyConverter.java
+++ b/src/main/java/edu/kit/kastel/mcse/ardoco/tlr/rest/api/converter/InconsistencyConverter.java
@@ -1,4 +1,4 @@
-/* Licensed under MIT 2025. */
+/* Licensed under MIT 2025-2026. */
 package edu.kit.kastel.mcse.ardoco.tlr.rest.api.converter;
 
 import org.eclipse.collections.api.list.ImmutableList;
@@ -9,8 +9,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import edu.kit.kastel.mcse.ardoco.core.api.stage.inconsistency.Inconsistency;
-import edu.kit.kastel.mcse.ardoco.id.types.MissingModelInstanceInconsistency;
-import edu.kit.kastel.mcse.ardoco.id.types.MissingTextForModelElementInconsistency;
+import edu.kit.kastel.mcse.ardoco.id.types.ModelEntityAbsentFromTextInconsistency;
+import edu.kit.kastel.mcse.ardoco.id.types.TextEntityAbsentFromModelInconsistency;
 
 public final class InconsistencyConverter {
 
@@ -26,12 +26,12 @@ public final class InconsistencyConverter {
             ObjectNode traceLinkNode = objectMapper.createObjectNode();
             traceLinkNode.put("type", inconsistency.getType());
             traceLinkNode.put("reason", inconsistency.getReason());
-            if (inconsistency.getType().equals("MissingModelInstance")) {
-                MissingModelInstanceInconsistency mmiInconsistency = (MissingModelInstanceInconsistency) inconsistency;
-                traceLinkNode.put("sentenceNumber", mmiInconsistency.getSentenceNumber());
-            } else if (inconsistency.getType().equals("MissingTextForModelElement")) {
-                MissingTextForModelElementInconsistency umeInconsistency = (MissingTextForModelElementInconsistency) inconsistency;
-                traceLinkNode.put("modelElementId", umeInconsistency.getModelInstanceUid());
+            if (inconsistency.getType().equals("TextEntityAbsentFromModel")) {
+                TextEntityAbsentFromModelInconsistency teamInconsistency = (TextEntityAbsentFromModelInconsistency) inconsistency;
+                traceLinkNode.put("sentenceNumber", teamInconsistency.getSentenceNumber());
+            } else if (inconsistency.getType().equals("ModelEntityAbsentFromText")) {
+                ModelEntityAbsentFromTextInconsistency meatInconsistency = (ModelEntityAbsentFromTextInconsistency) inconsistency;
+                traceLinkNode.put("modelElementId", meatInconsistency.getModelInstanceUid());
             }
             arrayNode.add(traceLinkNode);
         }


### PR DESCRIPTION
Rename Missing Model Elements (MME) to Text Entity Absent from Model (TEAM) and Undocumented Model Elements (UME) to Model Entity Absent from Text (MEAT) to use clearer, more descriptive terminology.

This commit includes:
- Renamed Java classes for both inconsistency types and their agents
- Updated REST API to use new type identifiers
- Updated TypeScript/React frontend (traceview-v2) components and data models
- Updated documentation and website content
- Cleaned up duplicate test files
- Added @SuppressWarnings annotations to test methods with null parameters

BREAKING CHANGE: REST API inconsistency type identifiers changed from "MissingModelInstance"/"MissingTextForModelElement" to "TextEntityAbsentFromModel"/"ModelEntityAbsentFromText"